### PR TITLE
add rewrite rule in htaccess to match rpc.php exactly

### DIFF
--- a/web/.htaccess
+++ b/web/.htaccess
@@ -12,6 +12,8 @@
     RewriteEngine On
     RewriteRule .* - [env=HTTP_AUTHORIZATION:%{HTTP:Authorization}]
     RewriteRule .* - [env=REDIRECT_HTTP_AUTHORIZATION:%{HTTP:Authorization}]
+    # Catch everything ending exactly in rpc.php
+    RewriteRule ^rpc\.php$ horde/rpc.php [QSA,L]
     # Catch all rewrites under rpc.php
     RewriteRule ^rpc\.php(.*)$ horde/rpc.php/$1 [QSA,L]
     # Catch everything in the /rpc/ dir


### PR DESCRIPTION
Added another rewrite rule in the .htaccess file for rpc.php.

Without the rule:
Requests on `horde.local/rpc.php` are redirected to `horde.local/horde/rpc.php/`. This breaks RPC, as Horde's rpc.php sees the trailing slash in `$_SERVER['PATH_INFO']` and considers it to always be a Webdav request, even though the original request in my case was Jsonrpc.

With the rule:
Requests on `horde.local/rpc.php` are redirected to `horde.local/horde/rpc.php`.